### PR TITLE
Update docker instructions and add M1 info

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker pull tpmdev/tpm2-runtime
 Generate random number using the TPM2 simulator:
 
 ```
-docker run --rm -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" tpmdev/tpm2-runtime:latest /bin/bash -c "tpm_server >/dev/null & sleep 1; tpm2_startup -c; tpm2_getrandom 64"
+docker run --rm -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" tpmdev/tpm2-runtime:latest /bin/bash -c "tpm_server >/dev/null & sleep 1; tpm2_startup -c; tpm2_getrandom 8"
 ```
 
 ### Running on Apple M1
@@ -33,7 +33,7 @@ docker run --rm -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" tpmdev/tpm2-r
 To run amd64 docker images on M1 requires an extra parameter `--platform linux/amd64`:
 
 ```
-docker run --rm --platform=linux/amd64 -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" tpmdev/tpm2-runtime:latest /bin/bash -c "tpm_server >/dev/null & sleep 1; tpm2_startup -c; tpm2_getrandom 64"
+docker run --rm --platform=linux/amd64 -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" tpmdev/tpm2-runtime:latest /bin/bash -c "tpm_server >/dev/null & sleep 1; tpm2_startup -c; tpm2_getrandom 8"
 ```
 
 ## What is [TPM.dev](https://www.tpm.dev)?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TPM.dev Docker image
-## _Development environment for TPM.dev Courses and TPM developers_
+## _Ready-to-use Development environment for TPM modules_
 
-This docker image is contribution by Matthew Giassa (member of TPM.dev). It contains:
+This docker image contains:
 * IBM TPM 2.0 Simulator
 * TCG compliant TPM2 Software Stack
 * TCG compliant TPM2 Resource Manager
@@ -9,6 +9,32 @@ This docker image is contribution by Matthew Giassa (member of TPM.dev). It cont
 * wolfTPM 2.0 stack for embedded systems
 
 All together for rapid TPM development and ease when participating in one of our TPM.dev courses.
+
+Acknowledgement: This docker image was started with a contribution by Matthew Giassa (member of TPM.dev). Later, it was improved upon. Pull-requests are welcome.
+
+## Quickstart
+
+Download our pre-built docker image that is ready for use:
+
+```
+docker pull tpmdev/tpm2-runtime
+```
+
+### Example run
+
+Generate random number using the TPM2 simulator:
+
+```
+docker run --rm -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" tpmdev/tpm2-runtime:latest /bin/bash -c "tpm_server >/dev/null & sleep 1; tpm2_startup -c; tpm2_getrandom 64"
+```
+
+### Running on Apple M1
+
+To run amd64 docker images on M1 requires an extra parameter `--platform linux/amd64`:
+
+```
+docker run --rm --platform=linux/amd64 -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" tpmdev/tpm2-runtime:latest /bin/bash -c "tpm_server >/dev/null & sleep 1; tpm2_startup -c; tpm2_getrandom 64"
+```
 
 ## What is [TPM.dev](https://www.tpm.dev)?
 
@@ -22,13 +48,3 @@ A place for developer-friendly computer security of IoT, Edge and Cloud systems.
 * Our conference presents industry professionals and commercial companies together with community projects and researchers
 
 Explore our resources here - [TPM.dev](https://www.tpm.dev)
-
-## Building
-
-To build the docker container type `make `
-
-## Example run
-
-```
-docker run --rm tpmdev/tpm2-runtime:latest -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" -c "tpm_server >/dev/null &; sleep 1; tpm2_startup; tpm2_getrandom 8"
-```


### PR DESCRIPTION
This PR updates our docker instructions to use the IBM TPM2 simulator by default. It also add instructions about running our pre-built docker image on Apple M1 silicon.